### PR TITLE
Fix app crashes for legacy app

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -19,9 +19,13 @@ class HomeButler {
 
   init () {
     // Wakeup the companion app
-    peerSocket.send({
-      command: 'wakeup'
-    })
+    try {
+      peerSocket.send({
+        command: 'wakeup'
+      })
+    } catch {
+      // fail silently if peerSocket is not OPEN
+    }
   }
 
   render (devices) {

--- a/app/index.js
+++ b/app/index.js
@@ -96,8 +96,17 @@ class HomeButler {
         const temperature = cardDOM.getElementById('temperature')
         const humidity = cardDOM.getElementById('humidity')
 
-        temperature.text = device.attributes.current_temperature + '°'
-        humidity.text = device.attributes.current_humidity + '%'
+        temperature.text =
+          device.attributes.current_temperature !== undefined &&
+          device.attributes.current_temperature !== null
+            ? device.attributes.current_temperature + "°"
+            : "";
+
+        humidity.text =
+          device.attributes.current_humidity !== undefined &&
+          device.attributes.current_humidity !== undefined
+            ? device.attributes.current_humidity + "%"
+            : "";
 
         switch (device.state) {
           case 'heat_cool': {


### PR DESCRIPTION
I've found two troubles which lead to the app crashing on start on my home assistant.

The main cause was the temperature/humidity fields not being present all the time on my climate devices. `undefined %` was too long for the text buffer of the humidity text field.

Also, the `peerSocket.send` for the wakup command in the app's `init` method fails all the time because the `peerSocket` is still starting and not open at this point. I'm not 100% sure if silently failing is the best way but it works a bit smoother over here. If I still run into troubles in the next time, I might try some "wait until the peerSocket is connected" approach before sending the wakup message.